### PR TITLE
Auto update criteria when they change

### DIFF
--- a/.github/workflows/criteria-updater.yml
+++ b/.github/workflows/criteria-updater.yml
@@ -1,0 +1,33 @@
+name: Self update eligibility criteria
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '*/15 * * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby 2.7
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - name: Update English criteria JSON
+        run: bundle exec ruby lib/criteria_updater.rb data/england.json
+      - name: Save data
+        env:
+          GIT_OWNER_EMAIL: ${{ secrets.GIT_OWNER_EMAIL }}
+          PUSH_TOKEN: ${{ secrets.PUSH_TOKEN }}
+        run: |
+          if [[ `git status --porcelain` ]]; then
+            git config --global user.name 'iamdanw-bot'
+            git config --global user.email 'iamdanw-bot@users.noreply.github.com'
+            git commit -am "Add latest eligibility criteria"
+            git push
+          else
+            echo 'No changes to commit'
+          fi

--- a/lib/criteria_store.rb
+++ b/lib/criteria_store.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class CriteriaStore
+  attr_reader :criteria
+
   def initialize(criteria)
     @criteria = criteria
   end

--- a/lib/criteria_store.rb
+++ b/lib/criteria_store.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class CriteriaStore
+  def initialize(criteria)
+    @criteria = criteria
+  end
+
+  def latest
+    @criteria.max do |a, b|
+      a['updated_at'] <=> b['updated_at']
+    end
+  end
+end

--- a/lib/criteria_store.rb
+++ b/lib/criteria_store.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class CriteriaStore
+  class DuplicateCriteriaError < StandardError
+  end
+
   attr_reader :criteria
 
   def initialize(criteria)
@@ -14,6 +17,8 @@ class CriteriaStore
   end
 
   def add(new_criteria, updated_at)
+    raise DuplicateCriteriaError if new_criteria.sort == latest['criteria'].sort
+
     @criteria.push(
       {
         'updated_at' => updated_at,

--- a/lib/criteria_store.rb
+++ b/lib/criteria_store.rb
@@ -12,4 +12,13 @@ class CriteriaStore
       a['updated_at'] <=> b['updated_at']
     end
   end
+
+  def add(new_criteria, updated_at)
+    @criteria.push(
+      {
+        'updated_at' => updated_at,
+        'criteria' => new_criteria
+      }
+    )
+  end
 end

--- a/lib/criteria_updater.rb
+++ b/lib/criteria_updater.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'json'
+require 'open-uri'
+
+require('./lib/criteria_store')
+require('./lib/criteria_extractor')
+
+class CriteriaUpdater
+  def initialize(args)
+    @file_path = args[0]
+    criteria_hash = load_criteria(@file_path)
+
+    @criteria_store = CriteriaStore.new(criteria_hash)
+  end
+
+  def run
+    extracted_criteria = fetch_latest_criteria
+
+    @criteria_store.add(
+      extracted_criteria.criteria,
+      extracted_criteria.updated_at.iso8601
+    )
+
+    save_criteria(@criteria_store.criteria, @file_path)
+  end
+
+  private
+
+  def fetch_latest_criteria
+    url = 'https://www.nhs.uk/conditions/coronavirus-covid-19/coronavirus-vaccination/book-coronavirus-vaccination/'
+    page = URI.parse(url).open.read
+    CriteriaExtractor.new(page)
+  end
+
+  def load_criteria(file_path)
+    file = File.read(file_path)
+    JSON.parse(file)
+  end
+
+  def save_criteria(criteria, file_path)
+    json_out = JSON.pretty_generate(criteria)
+    File.write(file_path, json_out)
+  end
+end
+
+# Use Ruby constants to make the file runnable from the command line
+CriteriaUpdater.new(ARGV).run if $PROGRAM_NAME == __FILE__

--- a/spec/criteria_store_spec.rb
+++ b/spec/criteria_store_spec.rb
@@ -39,4 +39,10 @@ RSpec.describe CriteriaStore do
       expect(criteria_store.latest).to eq latest_entry
     end
   end
+
+  describe '#criteria' do
+    it 'returns all the criteria' do
+      expect(criteria_store.criteria).to eq example_criteria
+    end
+  end
 end

--- a/spec/criteria_store_spec.rb
+++ b/spec/criteria_store_spec.rb
@@ -47,27 +47,49 @@ RSpec.describe CriteriaStore do
   end
 
   describe '#add' do
-    let(:new_criteria) do
-      [
-        'you are aged 40 or over',
-        'you are at high risk from coronavirus (clinically extremely vulnerable)',
-        'you are an eligible frontline health or social care worker',
-        'you have a condition that puts you at higher risk (clinically vulnerable)',
-        'you have a learning disability',
-        'you are a main carer for someone at high risk from coronavirus',
-        'you are in a higher risk profession'
-      ]
-    end
     let(:updated_at) { '2021-04-30T06:52:00+01:00' }
 
-    it 'stores the updated_at timestamp' do
-      criteria_store.add(new_criteria, updated_at)
-      expect(criteria_store.latest['updated_at']).to eq updated_at
+    context 'when the criteria is not a duplicate' do
+      let(:new_criteria) do
+        [
+          'you are aged 40 or over',
+          'you are at high risk from coronavirus (clinically extremely vulnerable)',
+          'you are an eligible frontline health or social care worker',
+          'you have a condition that puts you at higher risk (clinically vulnerable)',
+          'you have a learning disability',
+          'you are a main carer for someone at high risk from coronavirus',
+          'you are in a higher risk profession'
+        ]
+      end
+
+      it 'stores the updated_at timestamp' do
+        criteria_store.add(new_criteria, updated_at)
+        expect(criteria_store.latest['updated_at']).to eq updated_at
+      end
+
+      it 'stores the criteria' do
+        criteria_store.add(new_criteria, updated_at)
+        expect(criteria_store.latest['criteria']).to match_array(new_criteria)
+      end
     end
 
-    it 'stores the criteria' do
-      criteria_store.add(new_criteria, updated_at)
-      expect(criteria_store.latest['criteria']).to match_array(new_criteria)
+    context 'when the criteria is a duplicate' do
+      let(:duplicate_criteria) do
+        [
+          'you are aged 55 or over',
+          'you are at high risk from coronavirus (clinically extremely vulnerable)',
+          'you are an eligible frontline health or social care worker',
+          'you have a condition that puts you at higher risk (clinically vulnerable)',
+          'you have a learning disability',
+          'you are a main carer for someone at high risk from coronavirus'
+        ]
+      end
+
+      it 'raises an error' do
+        expect do
+          criteria_store.add(duplicate_criteria, updated_at)
+        end.to raise_error(CriteriaStore::DuplicateCriteriaError)
+      end
     end
   end
 end

--- a/spec/criteria_store_spec.rb
+++ b/spec/criteria_store_spec.rb
@@ -45,4 +45,29 @@ RSpec.describe CriteriaStore do
       expect(criteria_store.criteria).to eq example_criteria
     end
   end
+
+  describe '#add' do
+    let(:new_criteria) do
+      [
+        'you are aged 40 or over',
+        'you are at high risk from coronavirus (clinically extremely vulnerable)',
+        'you are an eligible frontline health or social care worker',
+        'you have a condition that puts you at higher risk (clinically vulnerable)',
+        'you have a learning disability',
+        'you are a main carer for someone at high risk from coronavirus',
+        'you are in a higher risk profession'
+      ]
+    end
+    let(:updated_at) { '2021-04-30T06:52:00+01:00' }
+
+    it 'stores the updated_at timestamp' do
+      criteria_store.add(new_criteria, updated_at)
+      expect(criteria_store.latest['updated_at']).to eq updated_at
+    end
+
+    it 'stores the criteria' do
+      criteria_store.add(new_criteria, updated_at)
+      expect(criteria_store.latest['criteria']).to match_array(new_criteria)
+    end
+  end
 end

--- a/spec/criteria_store_spec.rb
+++ b/spec/criteria_store_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require('criteria_store')
+
+RSpec.describe CriteriaStore do
+  subject(:criteria_store) { described_class.new(example_criteria) }
+
+  let(:latest_entry) do
+    {
+      'updated_at' => '2021-03-08T17:09:00+00:00',
+      'criteria' => [
+        'you are aged 55 or over',
+        'you are at high risk from coronavirus (clinically extremely vulnerable)',
+        'you are an eligible frontline health or social care worker',
+        'you have a condition that puts you at higher risk (clinically vulnerable)',
+        'you have a learning disability',
+        'you are a main carer for someone at high risk from coronavirus'
+      ]
+    }
+  end
+  let(:example_criteria) do
+    [
+      {
+        'updated_at' => '2021-03-03T17:25:00+00:00',
+        'criteria' => [
+          'you are aged 60 or over',
+          'you are at high risk from coronavirus (clinically extremely vulnerable)',
+          'you are an eligible frontline health or social care worker',
+          'you have a condition that puts you at higher risk (clinically vulnerable)',
+          'you are a main carer for someone at high risk from coronavirus'
+        ]
+      },
+      latest_entry
+    ]
+  end
+
+  describe '#latest' do
+    it 'returns the most recently captured criteria' do
+      expect(criteria_store.latest).to eq latest_entry
+    end
+  end
+end


### PR DESCRIPTION
I want this repo to be a structured way of storing the history of English vaccination criteria changes.

Currently I am doing this by manually updating, or scraping the archive.org wayback machine history of the NHS booking page.

Sometimes there are gaps in the archive that miss a criteria change, and I could miss manually adding a criteria change.

So instead I am adding a github actions workflow to keep checking the NHS page, and to update the `data/england.json` file when there has been a change.