### PR TITLE
Fix storing duplicate criteria

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,3 +24,6 @@ Style/Documentation:
 
 Metrics/BlockLength:
   Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false

--- a/lib/criteria_store.rb
+++ b/lib/criteria_store.rb
@@ -17,7 +17,7 @@ class CriteriaStore
   end
 
   def add(new_criteria, updated_at)
-    raise DuplicateCriteriaError if new_criteria.sort == latest['criteria'].sort
+    raise DuplicateCriteriaError unless find_matching_criteria(new_criteria).empty?
 
     @criteria.push(
       {
@@ -37,5 +37,11 @@ class CriteriaStore
   def extract_min_age_from_criteria(criteria)
     age_criteria = match_first_criteria(criteria, 'aged')
     age_criteria[/(\d+)/, 1].to_i
+  end
+
+  def find_matching_criteria(criteria_to_match)
+    @criteria.filter do |c|
+      criteria_to_match.sort == c['criteria'].sort
+    end
   end
 end

--- a/spec/criteria_store_spec.rb
+++ b/spec/criteria_store_spec.rb
@@ -81,21 +81,41 @@ RSpec.describe CriteriaStore do
     end
 
     context 'when the criteria is a duplicate' do
-      let(:duplicate_criteria) do
-        [
-          'you are aged 55 or over',
-          'you are at high risk from coronavirus (clinically extremely vulnerable)',
-          'you are an eligible frontline health or social care worker',
-          'you have a condition that puts you at higher risk (clinically vulnerable)',
-          'you have a learning disability',
-          'you are a main carer for someone at high risk from coronavirus'
-        ]
+      context 'when the most recent stored criteria is duplicated' do
+        let(:duplicate_criteria) do
+          [
+            'you are aged 55 or over',
+            'you are at high risk from coronavirus (clinically extremely vulnerable)',
+            'you are an eligible frontline health or social care worker',
+            'you have a condition that puts you at higher risk (clinically vulnerable)',
+            'you have a learning disability',
+            'you are a main carer for someone at high risk from coronavirus'
+          ]
+        end
+
+        it 'raises an error' do
+          expect do
+            criteria_store.add(duplicate_criteria, updated_at)
+          end.to raise_error(CriteriaStore::DuplicateCriteriaError)
+        end
       end
 
-      it 'raises an error' do
-        expect do
-          criteria_store.add(duplicate_criteria, updated_at)
-        end.to raise_error(CriteriaStore::DuplicateCriteriaError)
+      context 'when an older stored criteria is duplicated' do
+        let(:duplicate_criteria) do
+          [
+            'you are aged 60 or over',
+            'you are at high risk from coronavirus (clinically extremely vulnerable)',
+            'you are an eligible frontline health or social care worker',
+            'you have a condition that puts you at higher risk (clinically vulnerable)',
+            'you are a main carer for someone at high risk from coronavirus'
+          ]
+        end
+
+        it 'raises an error' do
+          expect do
+            criteria_store.add(duplicate_criteria, updated_at)
+          end.to raise_error(CriteriaStore::DuplicateCriteriaError)
+        end
       end
     end
   end


### PR DESCRIPTION
Last week the NHS website was occasionally returning a cached version of
the page with out of date criteria (36+).

Because we were only checking against the 'latest' stored criteria (34+
at the time) we were not detecting the duplicate and ended up with three
36+ entries.

This change checks against all stored criteria for duplicates.

It is possible that published criteria may move 'backwards'
deliberately, eg the age range deliberately moves back to 36+. This
would be rejected by CriteriaStore#add, but if that happens I will deal
with it then.